### PR TITLE
Documentation fix

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -56,6 +56,7 @@ cd desafio-backend-soluct
 ### 2. Rodar com Docker
 
 ```bash
+cd backend
 cp .env.example .env
 docker-compose up -d
 docker exec -it soluct-app composer install


### PR DESCRIPTION
docs: add missing command to navigate to backend directory in README